### PR TITLE
Events consider human readable barcodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
-sudo: false
+dist: xenial
+sudo: required
+services:
+  - mysql
+  - xvfb
 cache: bundler
 before_install:
   - export TZ=Europe/London

--- a/app/models/process_plate.rb
+++ b/app/models/process_plate.rb
@@ -24,7 +24,7 @@ class ProcessPlate < ActiveRecord::Base
   end
 
   def barcodes
-    source_plates.scan(/\d+/).map { |plate| plate }
+    source_plates.scan(/\w+/).map { |plate| plate }
   end
 
   def instrument

--- a/test/support/test_search_result.rb
+++ b/test/support/test_search_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TestSearchResult
+  attr_accessor :barcode, :uuid
+  def initialize(machine_barcode, uuid: 'uuid')
+    # Not what actually happens, but it'll work for our purposes
+    encoded_barcode = machine_barcode.bytes.map { |b| (b % 48).to_s }.join
+    @uuid = uuid
+    @barcode = OpenStruct.new(ean13: encoded_barcode, machine: machine_barcode)
+  end
+end

--- a/test/support/test_sequencescape_api.rb
+++ b/test/support/test_sequencescape_api.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class TestSequencescapeApi
+  class CreatedStore
+    attr_reader :created
+
+    def initialize
+      @created = []
+    end
+
+    def create!(params)
+      @created << params
+    end
+  end
+
+  attr_accessor :plate
+  attr_accessor :barcode
+  attr_accessor :barcode_to_results
+
+  def initialize(barcode_to_results)
+    @barcode_to_results = barcode_to_results
+  end
+
+  def asset_audit
+    @asset_audit ||= CreatedStore.new
+  end
+
+  def search
+    self
+  end
+
+  def find(_search_uuid)
+    self
+  end
+
+  def all(_plate, options = {})
+    @barcode_to_results[options[:barcode]] || []
+  end
+end

--- a/test/unit/dilution_plate_verification_test.rb
+++ b/test/unit/dilution_plate_verification_test.rb
@@ -1,37 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
-
-class TestSequencescapeApi
-  attr_accessor :plate
-  attr_accessor :barcode
-  attr_accessor :barcode_to_results
-
-  def initialize(barcode_to_results)
-    @barcode_to_results = barcode_to_results
-  end
-
-  def search
-    self
-  end
-
-  def find(search_uuid)
-    self
-  end
-
-  def all(plate, options = {})
-    @barcode_to_results[options[:barcode]] || []
-  end
-end
-
-class TestSearchResult
-  attr_accessor :barcode
-  def initialize(machine_barcode)
-    # Not what actually happens, but it'll work for our purposes
-    encoded_barcode = machine_barcode.bytes.map { |b| (b % 48).to_s }.join
-    @barcode = OpenStruct.new(ean13: encoded_barcode, machine: machine_barcode)
-  end
-end
-
+require 'support/test_sequencescape_api'
+require 'support/test_search_result'
 
 class DilutionPlateVerificationTest < ActiveSupport::TestCase
   context 'Verifying the creation of dilution plates' do

--- a/test/unit/process_plate_test.rb
+++ b/test/unit/process_plate_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'support/test_sequencescape_api'
+require 'support/test_search_result'
+
+class ProcessPlateTest < ActiveSupport::TestCase
+  context 'Generating remote asset audits' do
+    setup do
+      ipi = Factory :instrument_processes_instrument
+      @instrument = ipi.instrument
+      @instrument_process = ipi.instrument_process
+    end
+
+    context 'where all parameters are valid' do
+      setup do
+        User.stubs(:login_from_user_code).with('123').returns('abc')
+        User.stubs(:login_from_user_code).with('456').returns('def')
+        @api = TestSequencescapeApi.new(['DN456S'] => [TestSearchResult.new('DN456S', uuid: 'plate-uuid')])
+
+        process_plate = ProcessPlate.new(
+          api: @api,
+          user_barcode: '123',
+          instrument_barcode: @instrument.barcode.to_s,
+          source_plates: 'DN456S',
+          visual_check: false,
+          instrument_process_id: @instrument.instrument_processes.first.id.to_s,
+          witness_barcode: '456'
+        )
+        process_plate.save
+        process_plate.create_audits_without_delay
+      end
+
+      should 'generate remote asset audits' do
+        assert_equal @api.asset_audit.created.length, 1
+        assert_equal(@api.asset_audit.created.first, key: @instrument_process.key,
+                                                     message: "Process '#{@instrument_process.name}' performed on instrument #{@instrument.name}",
+                                                     created_by: 'abc',
+                                                     asset: 'plate-uuid',
+                                                     witnessed_by: 'def')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The previous regular expression was splitting the barcodes into chunks
of digits, rather than words, which meant human readbale barcodes had
their numeric portion extracted. When this was used in the search no
plates were returned, to audit creation was skipped.

This change splits into chunks of /w which include all characters which
are part of the barcodes.

Whic commit also adds some testing for the delayed job itself, which was
previously missing.

This does not create missing audits. Doing this across the API will result in unreliable timestamps.