### PR TITLE
Logger fix

### DIFF
--- a/app/models/verification/validator/beds_and_plates_scanned.rb
+++ b/app/models/verification/validator/beds_and_plates_scanned.rb
@@ -13,6 +13,7 @@ class Verification::Validator::BedsAndPlatesScanned < ActiveModel::Validator
 
   def valid_bed?(bed_name, bed_barcode, plate_barcode, record)
     return true if bed_barcode.blank? && plate_barcode.blank?
+
     if bed_barcode.present? && plate_barcode.present?
       bed = record.instrument.beds.detect { |bed| bed.name.downcase.to_s == bed_name.to_s }
       return false if bed.nil?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,6 @@ Rails.application.configure do
   # https://github.com/sanger/lighthouse
   config.lighthouse_host = 'http://127.0.0.1:5000'
 
-  config.logger = Logger.new(STDOUT)
   # config.logger.broadcast_messages = false
 
   # Use an evented file watcher to asynchronously detect changes in source code,


### PR DESCRIPTION
Use the default logger (ActiveSupport::Logger) in development mode
- The one being set was causing an issue when hitting 'submit' in quad_stamp process
- Error was due to logger not having the 'silence' method - see issue here - https://github.com/rails/sprockets-rails/issues/376
- Maybe wasn't an issue before because it's to do with retrieving assets and we've fiddled around with those recently?
