### PR TITLE
DPL-670-7 - Adds API Key for sequencescape v2 requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ To run the tests, execute the following commands:
 
     bundle exec rake
 
+To run a single test:
+
+    bundle exec rake test TEST=<test_file_path>
+
 ## Linting and formatting
 
 Rubocop is used for linting.

--- a/app/resources/sequencescape/api/v2/base.rb
+++ b/app/resources/sequencescape/api/v2/base.rb
@@ -3,4 +3,5 @@
 class Sequencescape::Api::V2::Base < JsonApiClient::Resource
   # set the api base url in an abstract base class
   self.site = Settings.sequencescape_api_v2
+  connection_options[:headers] = { "X-Sequencescape-Client-Id" => Settings.sequencescape_authorisation }
 end

--- a/test/unit/sequencescape_api_v2_test.rb
+++ b/test/unit/sequencescape_api_v2_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SequencescapeApiV2Test < ActiveSupport::TestCase
+  context "The base class is correct" do
+    should "Have the correct site" do
+      assert_equal(Sequencescape::Api::V2::Base.site, Settings.sequencescape_api_v2)
+    end
+
+    should "Have the correct connection options headers" do
+      headers = Sequencescape::Api::V2::Base.connection_options[:headers]
+
+      assert_equal(headers, { "X-Sequencescape-Client-Id" => Settings.sequencescape_authorisation })
+    end
+  end
+
+  context "Child classes (User) contain the correct data" do
+    should "Have the correct site" do
+      assert_equal(Sequencescape::Api::V2::User.site, Settings.sequencescape_api_v2)
+    end
+
+    should "Have the correct connection options headers" do
+      headers = Sequencescape::Api::V2::User.connection_options[:headers]
+
+      assert_equal(headers, { "X-Sequencescape-Client-Id" => Settings.sequencescape_authorisation })
+    end
+
+    should "Include the api key in the requests" do
+      # We can assert that the resource has the correct api key in the headers by the fact it is
+      # being successfully stubbed
+      stub_request(:get, %r{api/v2/users}).with(
+        headers: {
+          "X-Sequencescape-Client-Id" => Settings.sequencescape_authorisation
+        }
+      ).to_return(
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/vnd.api+json"
+          },
+          body: JSON.generate({ data: [{ attributes: { login: "12345" } }] })
+        }
+      )
+
+      user = Sequencescape::Api::V2::User.first
+      expect(user.type).to eq("users")
+    end
+  end
+end


### PR DESCRIPTION
Closes #500 

#### Changes proposed in this pull request

- adds sequencescape v2 api key header for all v2 requests

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
