### PR TITLE
Fix for SSL issue while accessing Labwhere API 

### DIFF
--- a/app/models/verification/labwhere_api.rb
+++ b/app/models/verification/labwhere_api.rb
@@ -39,11 +39,10 @@ module Verification::LabwhereApi
   # e.g url is http://labwhere/api/locations/info?barcode=location_barcode
   #     response body is { "depth": 2, "labwares": [{ "barcode": "labware-1-barcode" }, { "barcode": "labware-2-barcode" }] } # rubocop:disable Layout/LineLength
 
-  def location_info(barcode) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+  def location_info(barcode) # rubocop:disable Metrics/MethodLength
     uri = URI.join(BASE_URL, "locations/info")
     uri.query = URI.encode_www_form({ barcode: })
-    http = Net::HTTP.new(uri.host, uri.port)
-    response = http.request(Net::HTTP::Get.new(uri.request_uri, HEADERS))
+    response = Net::HTTP.get_response(uri, HEADERS)
     if response.is_a?(Net::HTTPSuccess)
       # Parse the response body
       response_body = JSON.parse(response.body)


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request
Replaced Net::HTTP.new  with Net::HTTP.get_response was to setup SSL automatically while making LabWhere API get calls

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
