### PR TITLE
y24-189 Move fresh_sevice_new_ticket_url to <env>.rb, not application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,9 +29,6 @@ module ProcessTracking
     config.assets.enabled = true
     config.assets.version = "1.0"
 
-    # FreshService URL
-    config.fresh_sevice_new_ticket_url = "https://sanger.freshservice.com/a/tickets/new"
-
     require "./lib/deployed_version"
 
     def self.application_string

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,4 +50,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # FreshService URL
+  config.fresh_sevice_new_ticket_url = "https://sanger.freshservice.com/a/tickets/new"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,7 @@ Rails.application.configure do
   config.active_support.test_order = :random
 
   config.admin_email = "example@example.com"
+
+  # FreshService URL
+  config.fresh_sevice_new_ticket_url = "https://sanger.freshservice.com/a/tickets/new"
 end


### PR DESCRIPTION


#### Changes proposed in this pull request

- Move config from application.rb, as this would mean duplication on the server


