### PR TITLE
fix: added missing syslog gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "uuidtools"
 
 gem "byebug"
 gem "puma"
+gem 'syslog'
 
 # Manage default records
 gem "record_loader"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,6 +386,8 @@ GEM
       syntax_tree (>= 2.0.1)
     sys-uname (1.3.1)
       ffi (~> 1.1)
+    syslog (0.3.0)
+      logger
     temple (0.10.3)
     thor (1.4.0)
     tilt (2.4.0)
@@ -467,6 +469,7 @@ DEPENDENCIES
   simplecov_json_formatter
   sinatra
   sprockets-rails (~> 3.4)
+  syslog
   timecop
   uuidtools
   webmock


### PR DESCRIPTION
Closes N/A

#### Changes proposed in this pull request

- Adds the missing gem `syslog` as it is no longer bundled into newer versions of Ruby

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
