### PR TITLE
fix: correct regex in barcode reader to include hyphen in valid characters

### DIFF
--- a/app/assets/javascripts/barcode_reader.js
+++ b/app/assets/javascripts/barcode_reader.js
@@ -2,7 +2,7 @@ CodeMirror.defineMode("barcode_reader", function (_) {
   function tokenBase(stream, state) {
     let ch = stream.next();
     if (/\w/.test(ch)) {
-      stream.eatWhile(/[\w.]/);
+      stream.eatWhile(/[\w.-]/);
       let readBarcode = stream.current();
       if (state.barcodes.indexOf(readBarcode) >= 0) {
         return "strong error";


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Fixed the regex so that hyphens would be seen as valid characters.
- Before this change, SQPU-33 would be highlighted as two different barcodes if duplicated, SPQU and 33.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
