### PR TITLE
[ruby] Update record_loader to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "puma"
 gem "syslog"
 
 # Manage default records
-gem "record_loader"
+gem 'record_loader', git: 'https://github.com/sanger/record_loader'
 
 group :development do
   gem "listen" # Hot reloading

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "puma"
 gem "syslog"
 
 # Manage default records
-gem "record_loader", git: "https://github.com/sanger/record_loader"
+gem "record_loader", git: "https://github.com/sanger/record_loader", tag: 'v1.1.0'
 
 group :development do
   gem "listen" # Hot reloading

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "puma"
 gem "syslog"
 
 # Manage default records
-gem "record_loader", git: "https://github.com/sanger/record_loader", tag: 'v1.1.0'
+gem "record_loader", git: "https://github.com/sanger/record_loader", tag: "v1.1.0"
 
 group :development do
   gem "listen" # Hot reloading

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "puma"
 gem "syslog"
 
 # Manage default records
-gem 'record_loader', git: 'https://github.com/sanger/record_loader'
+gem "record_loader", git: "https://github.com/sanger/record_loader"
 
 group :development do
   gem "listen" # Hot reloading

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 GIT
   remote: https://github.com/sanger/record_loader
-  revision: 031f4b8c9934738c1b72b0716864252f63c450b6
+  revision: 9e7f1b67c3eeee1895f1befc6a54682f11c02135
+  tag: v1.1.0
   specs:
-    record_loader (0.3.0)
+    record_loader (1.1.0)
+      psych (~> 5.0)
 
 GEM
   remote: http://rubygems.org/
@@ -268,6 +270,9 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
       reline (>= 0.6.0)
+    psych (5.3.1)
+      date
+      stringio
     public_suffix (7.0.5)
     puma (6.6.1)
       nio4r (~> 2.0)
@@ -398,6 +403,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    stringio (3.2.0)
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
     syntax_tree-haml (4.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/sanger/record_loader
+  revision: 031f4b8c9934738c1b72b0716864252f63c450b6
+  specs:
+    record_loader (0.3.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -307,7 +313,6 @@ GEM
       ffi (~> 1.0)
     rbs (3.5.3)
       logger
-    record_loader (0.2.0)
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -474,7 +479,7 @@ DEPENDENCIES
   puma
   rails (~> 7.0.7)
   rake
-  record_loader
+  record_loader!
   rspec-expectations
   rspec-mocks
   rubocop


### PR DESCRIPTION
Update's record loader to latest version for Ruby 3.

#### Changes proposed in this pull request

- Changes gem source from rubygems.org to GitHub
- Updates `record_loader` from `0.2.0` to `0.3.0` to `1.1.0` supporting Ruby 3.4 (this application) and beyond.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
